### PR TITLE
Убрать зависимость от cordova-plugin-add-swift-support в каждом плаги…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,7 +46,6 @@
                 <param name="ios-package" value="WebimSDK" />
             </feature>
         </config-file>
-        <dependency id="cordova-plugin-add-swift-support" version="~2.0.2"/>
         <source-file src="src/ios/MimeType.swift" />
         <source-file src="src/ios/WebimSDK.swift" />
         <source-file src="src/ios/WebimClientLibrary/Department.swift" />


### PR DESCRIPTION
…не. Зависимость от cordova-plugin-add-swift-support теперь реализуется в корневом config.xml приложения.

https://wiki.bssys.com/pages/viewpage.action?pageId=458753791